### PR TITLE
[BUGFIX] 초기 렌더링 시 summary 자동 초기화 문제 해결

### DIFF
--- a/src/components/routes/NoteDetail.jsx
+++ b/src/components/routes/NoteDetail.jsx
@@ -20,6 +20,7 @@ const NoteDetail = () => {
   const prevContentRef = useRef(content);
   const {handleAddNote, handleUpdateNote, handleDeleteNote} = handleNoteActions({navigate, dispatch, id})
   const {SET_STATE, SET_INIT, SET_SUMMARY} = NOTE_DETAIL
+  const hasMounted = useRef(false);
 
   useEffect(() => {
     if(id && !isUUID(id)){
@@ -35,11 +36,16 @@ const NoteDetail = () => {
         content: note.content || '', 
         summary: note.summary || ''
       })
+      prevContentRef.current = note.content
     } else {
       stateDispatch({type:SET_INIT})
     }
   },[note, SET_STATE, SET_INIT])
   useEffect(() => {
+    if(!hasMounted.current){
+      hasMounted.current = true;
+      return;
+    }
     if(content !== prevContentRef.current){
       stateDispatch({type:SET_SUMMARY, payload: ""})
       prevContentRef.current = content;

--- a/src/store/noteSelector.js
+++ b/src/store/noteSelector.js
@@ -1,3 +1,3 @@
 export const selectNoteById = (id) => (state) => {
-  return state.notes.find(e => e.id.toString() === id.toString());
+  return state.notes.lists.find(e => e.id.toString() === id.toString());
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #14

<br>

## 📝 작업 내용

- hasMounted ref를 사용해 최초 렌더링 때 useEffect 실행 방지
- note 데이터 로드 시 prevContentRef 초기화 추가
- content 변경 감지는 초기 렌더 이후부터만 수행하도록 개선

<br>

## 🖼 스크린샷

이미지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 노트 상세 페이지에서 초기 로딩 시 요약이 잘못 초기화되는 문제를 수정했습니다.
  * 노트 선택 기능이 내부 데이터 구조 변경에 맞게 정상 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->